### PR TITLE
Update CsWin32 dependencies and configurations

### DIFF
--- a/src/WinQuickLook.App/WinQuickLook.App.csproj
+++ b/src/WinQuickLook.App/WinQuickLook.App.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WinQuickLook.App/packages.lock.json
+++ b/src/WinQuickLook.App/packages.lock.json
@@ -10,11 +10,11 @@
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Direct",
-        "requested": "[10.0.7, )",
-        "resolved": "10.0.7",
-        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "NijozhERJDIaJ4k5TSMy1jOi0cSC2HfkvRD/Sl+kGSSKgVbFnF4GxgtMN/MrzHB8D1JxIrD4xSer9Blh9v3axQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
       },
       "AvalonEdit": {
@@ -29,26 +29,26 @@
       },
       "Markdig": {
         "type": "Transitive",
-        "resolved": "1.1.3",
-        "contentHash": "wboYc6YToID7koq+onej7rjd/kv4urZaZ4QMiJoF/jXt/ZlXe2Af9gWG4nOe5tk654UaOPYvKL64iFum7qWEYA=="
+        "resolved": "1.3.2",
+        "contentHash": "fZgOC/3CswUrndjDTac70aQpYdtxbW5+5bRumR7vzvI2HJbkmgKisB1c9oT+GA6v0jB/JDR9BLa9FiPzQmaK6A=="
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+        "resolved": "10.0.9",
+        "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
-        "resolved": "1.0.3912.50",
-        "contentHash": "mEIKZDSmb6CxGWKoxaxTSJ0yi0DD2zp29TA7kJY2GdanuH3c5aYruwfqsm3OsYn/h2hUhybQZvfbxyZe4O+X4Q=="
+        "resolved": "1.0.4022.49",
+        "contentHash": "Dwewh8bbbXoFiF2y0jT3MBEV5ZXZVA7FDbMl6DixUCCLQAoymLMxMwqibdBaY/eWCG/BBSAILUOFDIzJZ9lfNQ=="
       },
       "winquicklook.core": {
         "type": "Project",
         "dependencies": {
           "AvalonEdit": "[6.3.1.120, )",
           "Cylinder.WPF": "[1.0.0-preview.2, )",
-          "Markdig": "[1.1.3, )",
-          "Microsoft.Web.WebView2": "[1.0.3912.50, )",
+          "Markdig": "[1.3.2, )",
+          "Microsoft.Web.WebView2": "[1.0.4022.49, )",
           "WinQuickLook.CsWin32": "[1.0.0, )"
         }
       },
@@ -59,15 +59,15 @@
     "net10.0-windows10.0.26100/win-arm64": {
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
-        "resolved": "1.0.3912.50",
-        "contentHash": "mEIKZDSmb6CxGWKoxaxTSJ0yi0DD2zp29TA7kJY2GdanuH3c5aYruwfqsm3OsYn/h2hUhybQZvfbxyZe4O+X4Q=="
+        "resolved": "1.0.4022.49",
+        "contentHash": "Dwewh8bbbXoFiF2y0jT3MBEV5ZXZVA7FDbMl6DixUCCLQAoymLMxMwqibdBaY/eWCG/BBSAILUOFDIzJZ9lfNQ=="
       }
     },
     "net10.0-windows10.0.26100/win-x64": {
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
-        "resolved": "1.0.3912.50",
-        "contentHash": "mEIKZDSmb6CxGWKoxaxTSJ0yi0DD2zp29TA7kJY2GdanuH3c5aYruwfqsm3OsYn/h2hUhybQZvfbxyZe4O+X4Q=="
+        "resolved": "1.0.4022.49",
+        "contentHash": "Dwewh8bbbXoFiF2y0jT3MBEV5ZXZVA7FDbMl6DixUCCLQAoymLMxMwqibdBaY/eWCG/BBSAILUOFDIzJZ9lfNQ=="
       }
     }
   }

--- a/src/WinQuickLook.Core/Providers/ShellAssociationProvider.cs
+++ b/src/WinQuickLook.Core/Providers/ShellAssociationProvider.cs
@@ -135,9 +135,9 @@ public class ShellAssociationProvider
 
                         PInvoke.SHCreateItemFromParsingName(fileInfo.FullName, null, out IShellItem shellItem);
 
-                        shellItem.BindToHandler(null, PInvoke.BHID_DataObject, typeof(Windows.Win32.System.Com.IDataObject).GUID, out var dataObject);
+                        shellItem.BindToHandler<Windows.Win32.System.Com.IDataObject>(null, PInvoke.BHID_DataObject, out var dataObject);
 
-                        assocHandler.Invoke((Windows.Win32.System.Com.IDataObject)dataObject);
+                        assocHandler.Invoke(dataObject);
 
                         Marshal.ReleaseComObject(dataObject);
                         Marshal.ReleaseComObject(shellItem);

--- a/src/WinQuickLook.Core/WinQuickLook.Core.csproj
+++ b/src/WinQuickLook.Core/WinQuickLook.Core.csproj
@@ -8,8 +8,8 @@
   <ItemGroup>
     <PackageReference Include="AvalonEdit" Version="6.3.1.120" />
     <PackageReference Include="Cylinder.WPF" Version="1.0.0-preview.2" />
-    <PackageReference Include="Markdig" Version="1.1.3" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3912.50" />
+    <PackageReference Include="Markdig" Version="1.3.2" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4022.49" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WinQuickLook.Core/packages.lock.json
+++ b/src/WinQuickLook.Core/packages.lock.json
@@ -16,15 +16,15 @@
       },
       "Markdig": {
         "type": "Direct",
-        "requested": "[1.1.3, )",
-        "resolved": "1.1.3",
-        "contentHash": "wboYc6YToID7koq+onej7rjd/kv4urZaZ4QMiJoF/jXt/ZlXe2Af9gWG4nOe5tk654UaOPYvKL64iFum7qWEYA=="
+        "requested": "[1.3.2, )",
+        "resolved": "1.3.2",
+        "contentHash": "fZgOC/3CswUrndjDTac70aQpYdtxbW5+5bRumR7vzvI2HJbkmgKisB1c9oT+GA6v0jB/JDR9BLa9FiPzQmaK6A=="
       },
       "Microsoft.Web.WebView2": {
         "type": "Direct",
-        "requested": "[1.0.3912.50, )",
-        "resolved": "1.0.3912.50",
-        "contentHash": "mEIKZDSmb6CxGWKoxaxTSJ0yi0DD2zp29TA7kJY2GdanuH3c5aYruwfqsm3OsYn/h2hUhybQZvfbxyZe4O+X4Q=="
+        "requested": "[1.0.4022.49, )",
+        "resolved": "1.0.4022.49",
+        "contentHash": "Dwewh8bbbXoFiF2y0jT3MBEV5ZXZVA7FDbMl6DixUCCLQAoymLMxMwqibdBaY/eWCG/BBSAILUOFDIzJZ9lfNQ=="
       },
       "winquicklook.cswin32": {
         "type": "Project"

--- a/src/WinQuickLook.CsWin32/FriendlyOverloadExtensions.cs
+++ b/src/WinQuickLook.CsWin32/FriendlyOverloadExtensions.cs
@@ -1,30 +1,12 @@
-﻿using System;
-
-using Windows.Win32.Foundation;
+﻿using Windows.Win32.Foundation;
 using Windows.Win32.UI.Shell;
-
-using IServiceProvider = Windows.Win32.System.Com.IServiceProvider;
 
 namespace Windows.Win32;
 
 public static class FriendlyOverloadExtensions
 {
-    public static HRESULT QueryService<T>(this IServiceProvider serviceProvider, in Guid guidService, out T ppvObject)
-    {
-        var hr = serviceProvider.QueryService(guidService, typeof(T).GUID, out var o);
-        ppvObject = (T)o;
-        return hr;
-    }
-
     extension(IFolderView folderView)
     {
-        public HRESULT GetFolder<T>(out T ppv)
-        {
-            var hr = folderView.GetFolder(typeof(T).GUID, out var o);
-            ppv = (T)o;
-            return hr;
-        }
-
         public unsafe void Item(int iItemIndex, out nint ppidl)
         {
             fixed (nint* ppidlLocal = &ppidl)

--- a/src/WinQuickLook.CsWin32/PInvoke.cs
+++ b/src/WinQuickLook.CsWin32/PInvoke.cs
@@ -19,20 +19,6 @@ public static partial class PInvoke
     public const uint MF_SOURCE_READER_FIRST_VIDEO_STREAM = 0xFFFFFFFCU;
     public const uint MF_SOURCE_READER_FIRST_AUDIO_STREAM = 0xFFFFFFFDU;
 
-    public static HRESULT SHCreateItemFromParsingName<T>(string pszPath, System.Com.IBindCtx? pbc, out T ppv)
-    {
-        var hr = SHCreateItemFromParsingName(pszPath, pbc, typeof(T).GUID, out var o);
-        ppv = (T)o;
-        return hr;
-    }
-
-    public static HRESULT SHGetPropertyStoreFromParsingName<T>(string pszPath, System.Com.IBindCtx? pbc, GETPROPERTYSTOREFLAGS flags, out T ppv)
-    {
-        var hr = SHGetPropertyStoreFromParsingName(pszPath, pbc, flags, typeof(T).GUID, out var o);
-        ppv = (T)o;
-        return hr;
-    }
-
     public static unsafe HWND CreateWindowEx2(WINDOW_EX_STYLE dwExStyle, string lpClassName, string lpWindowName, WINDOW_STYLE dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, SafeHandle? hMenu, SafeHandle? hInstance)
     {
         return CreateWindowEx(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, null);

--- a/src/WinQuickLook.CsWin32/WinQuickLook.CsWin32.csproj
+++ b/src/WinQuickLook.CsWin32/WinQuickLook.CsWin32.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.287">
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.298">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/WinQuickLook.CsWin32/packages.lock.json
+++ b/src/WinQuickLook.CsWin32/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0-windows10.0.26100": {
       "Microsoft.Windows.CsWin32": {
         "type": "Direct",
-        "requested": "[0.3.287, )",
-        "resolved": "0.3.287",
-        "contentHash": "4CUt0++zGiWsiD37wKQeFOQSvv1TK3FurvdWvcExAjMctnBWCG0WtNMyYVLNbyGa81eRUzY7milANwJUu3QcsA==",
+        "requested": "[0.3.298, )",
+        "resolved": "0.3.298",
+        "contentHash": "moz/CojV5HSeJYV9pNVE6mWMKnJGvPgdD31EhBLyUJ8Ui06PBrH9oPFK1ljXbJJMM4EzKnkE1a0AtBbH1BHDGA==",
         "dependencies": {
           "Microsoft.Windows.SDK.Win32Docs": "0.1.42-alpha",
           "Microsoft.Windows.SDK.Win32Metadata": "70.0.11-preview",

--- a/tests/WinQuickLook.Core.Tests/WinQuickLook.Core.Tests.csproj
+++ b/tests/WinQuickLook.Core.Tests/WinQuickLook.Core.Tests.csproj
@@ -16,13 +16,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/WinQuickLook.Core.Tests/packages.lock.json
+++ b/tests/WinQuickLook.Core.Tests/packages.lock.json
@@ -4,18 +4,18 @@
     "net10.0-windows10.0.26100": {
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[10.0.0, )",
-        "resolved": "10.0.0",
-        "contentHash": "WFejCcOUR6k8UYyDnnR6Gk+obFYMsWrZuNqPJnsVFGVhpPSN0y20D4qbdKJnXinYGx9PQ397Hf9TnU1NBST8vA=="
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "27jXSV/0DbVqF5jDrAxuQFZ9oaz6gmG03p8ttxAFk+X0M4woFYj7MoWDLCna5EGLb0CE6OE7X6ZH3Wt5smTtaA=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.5.1, )",
-        "resolved": "18.5.1",
-        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "requested": "[18.7.0, )",
+        "resolved": "18.7.0",
+        "contentHash": "49xH9j4UzCh2hMohJp53g3wUTvyycECw7CtVht4gfCz5ykudB1uBcF6D0TtgJPjCtP76UPW53bQElKdCeX+dUg==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.5.1",
-          "Microsoft.TestPlatform.TestHost": "18.5.1"
+          "Microsoft.CodeCoverage": "18.7.0",
+          "Microsoft.TestPlatform.TestHost": "18.7.0"
         }
       },
       "Moq": {
@@ -71,8 +71,8 @@
       },
       "Markdig": {
         "type": "Transitive",
-        "resolved": "1.1.3",
-        "contentHash": "wboYc6YToID7koq+onej7rjd/kv4urZaZ4QMiJoF/jXt/ZlXe2Af9gWG4nOe5tk654UaOPYvKL64iFum7qWEYA=="
+        "resolved": "1.3.2",
+        "contentHash": "fZgOC/3CswUrndjDTac70aQpYdtxbW5+5bRumR7vzvI2HJbkmgKisB1c9oT+GA6v0jB/JDR9BLa9FiPzQmaK6A=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -86,8 +86,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.5.1",
-        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+        "resolved": "18.7.0",
+        "contentHash": "+wFfx9s7D9wegM0RziXMj2kvYDT4qcqXXtyjiQwSZOGQ2wwcOAJQcD6eQXk02jt0MvRNawtp8TJxTrV+wD8X1g=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -121,22 +121,22 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.5.1",
-        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
+        "resolved": "18.7.0",
+        "contentHash": "6rmgU4q3/WOpOPcncI0YW0Q/QpcQtwR2TTEXDR5+4TfSimPBAk6Z/BgKLeGgp1SOun0ROVUCCafXhRLwsHaPpA=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.5.1",
-        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
+        "resolved": "18.7.0",
+        "contentHash": "kYwfmebCs8992zaxEDkvG7S+YEouTeKfYVKUFEkwh1W2dIoOaevBt80XSKVXCUFEhusjOIm1sFfHBnoJgygrRA==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
+          "Microsoft.TestPlatform.ObjectModel": "18.7.0",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
-        "resolved": "1.0.3912.50",
-        "contentHash": "mEIKZDSmb6CxGWKoxaxTSJ0yi0DD2zp29TA7kJY2GdanuH3c5aYruwfqsm3OsYn/h2hUhybQZvfbxyZe4O+X4Q=="
+        "resolved": "1.0.4022.49",
+        "contentHash": "Dwewh8bbbXoFiF2y0jT3MBEV5ZXZVA7FDbMl6DixUCCLQAoymLMxMwqibdBaY/eWCG/BBSAILUOFDIzJZ9lfNQ=="
       },
       "Microsoft.Win32.Registry": {
         "type": "Transitive",
@@ -225,8 +225,8 @@
         "dependencies": {
           "AvalonEdit": "[6.3.1.120, )",
           "Cylinder.WPF": "[1.0.0-preview.2, )",
-          "Markdig": "[1.1.3, )",
-          "Microsoft.Web.WebView2": "[1.0.3912.50, )",
+          "Markdig": "[1.3.2, )",
+          "Microsoft.Web.WebView2": "[1.0.4022.49, )",
           "WinQuickLook.CsWin32": "[1.0.0, )"
         }
       },


### PR DESCRIPTION
This pull request primarily updates several NuGet package dependencies across the solution to their latest versions, improving compatibility and security. Additionally, it refactors some COM interop code to use more type-safe generic overloads and removes some unused extension methods, simplifying the codebase.

**Dependency Updates:**

* Upgraded `Markdig` from version 1.1.3 to 1.3.2 and `Microsoft.Web.WebView2` from 1.0.3912.50 to 1.0.4022.49 in both `WinQuickLook.Core` and `WinQuickLook.App` projects, as well as their test projects. [[1]](diffhunk://#diff-315b3e28578136b08fd4c4c12a3b661f2d4de419ead2000a0d949f09179644b0L11-R12) [[2]](diffhunk://#diff-94131fd760d732f3e3307ecb67586573da8d6eee58f3c77b47dafeeaebf48afbL19-R27) [[3]](diffhunk://#diff-d9fb927435a2fdbafcb6b8eba13d0be7c0be099585bbe996d49fa59251d59126L32-R51) [[4]](diffhunk://#diff-d9fb927435a2fdbafcb6b8eba13d0be7c0be099585bbe996d49fa59251d59126L62-R70) [[5]](diffhunk://#diff-418af96fb9593025eab96b2a15b9d8e906fb15dd8c934b6c0cb4321597bfeeafL74-R75) [[6]](diffhunk://#diff-418af96fb9593025eab96b2a15b9d8e906fb15dd8c934b6c0cb4321597bfeeafL124-R139) [[7]](diffhunk://#diff-418af96fb9593025eab96b2a15b9d8e906fb15dd8c934b6c0cb4321597bfeeafL228-R229)
* Upgraded `Microsoft.Extensions.DependencyInjection` from 10.0.7 to 10.0.9 in `WinQuickLook.App`. [[1]](diffhunk://#diff-55e667e04573526ada779bc83ef55b37fb59e569aacfc3691399ac19e4565b53L21-R21) [[2]](diffhunk://#diff-d9fb927435a2fdbafcb6b8eba13d0be7c0be099585bbe996d49fa59251d59126L13-R17)
* Upgraded `Microsoft.Windows.CsWin32` from 0.3.287 to 0.3.298 in `WinQuickLook.CsWin32`. [[1]](diffhunk://#diff-bff3622e1c00ff19ccadbc9cf0d37b8457e689f9aebfe2afb3b5ac5ff2fc23a8L9-R9) [[2]](diffhunk://#diff-c5a6d88cca34e911607cdc63902271074e2507f90f608109b2354e757a21e82dL7-R9)
* Upgraded test dependencies: `Microsoft.NET.Test.Sdk` to 18.7.0 and `coverlet.collector` to 10.0.1 in `WinQuickLook.Core.Tests`. [[1]](diffhunk://#diff-3de01d88df555e86eb21e85cf9f86a0d8fac8d94f648509114f75f2ff9a2b1bfL19-R25) [[2]](diffhunk://#diff-418af96fb9593025eab96b2a15b9d8e906fb15dd8c934b6c0cb4321597bfeeafL7-R18) [[3]](diffhunk://#diff-418af96fb9593025eab96b2a15b9d8e906fb15dd8c934b6c0cb4321597bfeeafL89-R90) [[4]](diffhunk://#diff-418af96fb9593025eab96b2a15b9d8e906fb15dd8c934b6c0cb4321597bfeeafL124-R139)

**Code Refactoring and Cleanup:**

* Refactored COM interop calls in `ShellAssociationProvider.cs` to use type-safe generic overloads, improving code clarity and reducing the need for manual casting.
* Removed unused generic extension methods from `FriendlyOverloadExtensions.cs` and `PInvoke.cs`, simplifying the codebase. [[1]](diffhunk://#diff-12898aab8c57692b6650b238cf0cc10f2991da4515d84a0fc588e8dd865037c4L1-L27) [[2]](diffhunk://#diff-f6abbc28925e293ef77a1b216db7f0df773bc006ba1204bc75e8a828aec60291L22-L35)